### PR TITLE
Enhanced completion proposals in Parameter completion

### DIFF
--- a/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
+++ b/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
@@ -205,8 +205,14 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 
 	}
 
+    @Override
+    public void dispose()
+    {
+        ac = null;
+        super.dispose();
+    }
 
-	/**
+    /**
 	 * Sets the currently displayed description and updates the history.
 	 *
 	 * @param historyItem The item to add to the history.

--- a/src/main/java/org/fife/ui/autocomplete/AutoCompletePopupWindow.java
+++ b/src/main/java/org/fife/ui/autocomplete/AutoCompletePopupWindow.java
@@ -187,8 +187,18 @@ class AutoCompletePopupWindow extends JWindow implements CaretListener,
 
 	}
 
+    @Override
+    public void dispose()
+    {
+        ac = null;
+        if (descWindow != null) {
+            descWindow.dispose();
+            descWindow = null;
+        }
+        super.dispose();
+    }
 
-	@Override
+    @Override
 	public void caretUpdate(CaretEvent e) {
 		if (isVisible()) { // Should always be true
 			int line = ac.getLineOfCaret();

--- a/src/main/java/org/fife/ui/autocomplete/AutoCompletion.java
+++ b/src/main/java/org/fife/ui/autocomplete/AutoCompletion.java
@@ -1220,6 +1220,8 @@ public class AutoCompletion {
 
 			textComponent = null;
 			popupWindowListener.uninstall(popupWindow);
+            // release system resources
+            if (popupWindow != null) popupWindow.dispose();
 			popupWindow = null;
 
 		}

--- a/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionChoicesWindow.java
+++ b/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionChoicesWindow.java
@@ -116,8 +116,14 @@ public class ParameterizedCompletionChoicesWindow extends JWindow {
 
 	}
 
+    @Override
+    public void dispose()
+    {
+        ac = null;
+        super.dispose();
+    }
 
-	/**
+    /**
 	 * Returns the selected value.
 	 *
 	 * @return The selected value, or <code>null</code> if nothing is
@@ -133,14 +139,21 @@ public class ParameterizedCompletionChoicesWindow extends JWindow {
 	 * Changes the selected index.
 	 *
 	 * @param amount The amount by which to change the selected index.
+     * @param cyclic true if the selection should go around, false, if it should stop at first or last item
 	 */
-	public void incSelection(int amount) {
+	public void incSelection(int amount, boolean cyclic) {
 		int selection = list.getSelectedIndex();
 		selection += amount;
-		if (selection<0) {
+		if (selection < 0 && cyclic) {
 			// Account for nothing selected yet
 			selection = model.getSize()-1;//+= model.getSize();
 		}
+        else if (selection < 0) {
+            selection = 0;
+        }
+        else if (selection >= model.getSize() && !cyclic) {
+            selection = model.getSize() - 1;
+        }
 		else {
 			selection %= model.getSize();
 		}
@@ -225,6 +238,7 @@ public class ParameterizedCompletionChoicesWindow extends JWindow {
 
 		model.clear();
 		List<Completion> temp = new ArrayList<Completion>();
+        List<String> prefixParts = Util.getTextParts(prefix);
 
 		if (choicesListList!=null && param>=0 && param<choicesListList.size()) {
 
@@ -232,7 +246,7 @@ public class ParameterizedCompletionChoicesWindow extends JWindow {
 			if (choices!=null) {
 				for (Completion c : choices) {
 					String choice = c.getReplacementText();
-					if (prefix==null || Util.startsWithIgnoreCase(choice, prefix)) {
+					if (prefix==null || Util.startsWithIgnoreCase(choice, prefix) || Util.matchTextParts(prefixParts, Util.getTextParts(choice))) {
 						temp.add(c);
 					}
 				}

--- a/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionContext.java
+++ b/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionContext.java
@@ -147,6 +147,10 @@ class ParameterizedCompletionContext {
 	private Action oldUpAction;
 	private Object oldDownKey;
 	private Action oldDownAction;
+    private Object oldPageUpKey;
+    private Action oldPageUpAction;
+    private Object oldPageDownKey;
+    private Action oldPageDownAction;
 	private Object oldEnterKey;
 	private Action oldEnterAction;
 	private Object oldEscapeKey;
@@ -158,6 +162,8 @@ class ParameterizedCompletionContext {
 	private static final String IM_KEY_SHIFT_TAB = "ParamCompKey.ShiftTab";
 	private static final String IM_KEY_UP = "ParamCompKey.Up";
 	private static final String IM_KEY_DOWN = "ParamCompKey.Down";
+    private static final String IM_KEY_PAGEUP = "ParamCompKey.PageUp";
+    private static final String IM_KEY_PAGEDOWN = "ParamCompKey.PageDown";
 	private static final String IM_KEY_ESCAPE = "ParamCompKey.Escape";
 	private static final String IM_KEY_ENTER = "ParamCompKey.Enter";
 	private static final String IM_KEY_CLOSING = "ParamCompKey.Closing";
@@ -262,6 +268,8 @@ class ParameterizedCompletionContext {
 		}
 		if (paramChoicesWindow!=null) {
 			paramChoicesWindow.setVisible(false);
+            paramChoicesWindow.dispose();
+            paramChoicesWindow = null;
 		}
 	}
 
@@ -482,15 +490,27 @@ class ParameterizedCompletionContext {
 		oldUpKey = im.get(ks);
 		im.put(ks, IM_KEY_UP);
 		oldUpAction = am.get(IM_KEY_UP);
-		am.put(IM_KEY_UP, new NextChoiceAction(-1, oldUpAction));
+		am.put(IM_KEY_UP, new NextChoiceAction(-1, oldUpAction, true));
 
 		ks = KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0);
 		oldDownKey = im.get(ks);
 		im.put(ks, IM_KEY_DOWN);
 		oldDownAction = am.get(IM_KEY_DOWN);
-		am.put(IM_KEY_DOWN, new NextChoiceAction(1, oldDownAction));
+		am.put(IM_KEY_DOWN, new NextChoiceAction(1, oldDownAction, true));
 
-		ks = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
+        ks = KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_UP, 0);
+        oldPageUpKey = im.get(ks);
+        im.put(ks, IM_KEY_PAGEUP);
+        oldPageUpAction = am.get(IM_KEY_PAGEUP);
+        am.put(IM_KEY_PAGEUP, new NextChoiceAction(-8, oldPageUpAction, false));
+
+        ks = KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_DOWN, 0);
+        oldPageDownKey = im.get(ks);
+        im.put(ks, IM_KEY_PAGEDOWN);
+        oldPageDownAction = am.get(IM_KEY_PAGEDOWN);
+        am.put(IM_KEY_PAGEDOWN, new NextChoiceAction(8, oldPageDownAction, false));
+
+        ks = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
 		oldEnterKey = im.get(ks);
 		im.put(ks, IM_KEY_ENTER);
 		oldEnterAction = am.get(IM_KEY_ENTER);
@@ -781,7 +801,15 @@ class ParameterizedCompletionContext {
 		im.put(ks, oldDownKey);
 		am.put(IM_KEY_DOWN, oldDownAction);
 
-		ks = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
+        ks = KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_UP, 0);
+        im.put(ks, oldPageUpKey);
+        am.put(IM_KEY_PAGEUP, oldPageUpAction);
+
+        ks = KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_DOWN, 0);
+        im.put(ks, oldPageDownKey);
+        am.put(IM_KEY_PAGEDOWN, oldPageDownAction);
+
+        ks = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
 		im.put(ks, oldEnterKey);
 		am.put(IM_KEY_ENTER, oldEnterAction);
 
@@ -1185,16 +1213,18 @@ class ParameterizedCompletionContext {
 
 		private Action oldAction;
 		private int amount;
+        private boolean cyclic;
 
-		public NextChoiceAction(int amount, Action oldAction) {
+		public NextChoiceAction(int amount, Action oldAction, boolean cyclic) {
 			this.amount = amount;
 			this.oldAction = oldAction;
+            this.cyclic = cyclic;
 		}
 
 		@Override
 		public void actionPerformed(ActionEvent e) {
 			if (paramChoicesWindow!=null && paramChoicesWindow.isVisible()) {
-				paramChoicesWindow.incSelection(amount);
+				paramChoicesWindow.incSelection(amount, cyclic);
 			}
 			else if (oldAction!=null) {
 				oldAction.actionPerformed(e);
@@ -1244,6 +1274,4 @@ class ParameterizedCompletionContext {
 		}
 
 	}
-
-
 }

--- a/src/main/java/org/fife/ui/autocomplete/Util.java
+++ b/src/main/java/org/fife/ui/autocomplete/Util.java
@@ -16,6 +16,8 @@ import java.awt.Rectangle;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.security.AccessControlException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import javax.swing.JLabel;
@@ -319,5 +321,56 @@ public class Util {
 
 	}
 
+    /**
+     * Return text parts list for given text split at uppercase characters
+     *
+     * @param text
+     * @return
+     */
+    public static List<String> getTextParts(String text) {
+        List<String> textParts = new ArrayList<String>();
+        if (text == null || "".equals(text)) return textParts;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0;i < text.length();i++) {
+            if (Character.isUpperCase(text.charAt(i))) {
+                if (sb.length() > 0) {
+                    textParts.add(sb.toString());
+                    sb = new StringBuilder();
+                }
+            }
+            sb.append(text.charAt(i));
+        }
+        if (sb.length() > 0) textParts.add(sb.toString());
 
+        return textParts;
+    }
+
+    /**
+     * Compares two list of string if they share the same Uppercase segments.
+     *
+     * @param enteredText the text Parts for the entered text
+     * @param toBeMatched the text Parts for method, field, classname, etc.
+     * @return true if they match, false otherwise
+     */
+    public static boolean matchTextParts(List<String> enteredText, List<String> toBeMatched) {
+        if (toBeMatched.size() < enteredText.size()) return false;
+        for (int i = 0;i < enteredText.size();i++) {
+            if (!toBeMatched.get(i).startsWith(enteredText.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Compares two string if they share the same Uppercase segments. This method will
+     * create the string list for both parameter to be matched
+     *
+     * @param enteredText
+     * @param toBeMatched
+     * @return
+     */
+    public static boolean matchTextParts(String enteredText, String toBeMatched) {
+        return matchTextParts(getTextParts(enteredText), getTextParts(toBeMatched));
+    }
 }


### PR DESCRIPTION
I added IntelliJ like parameter completion proposals beside the current case-insensitive completion proposals. This means if user inputs chThVarO will match the variable name checkThisVariableOut. **These methods are in the Util class, and this is also used in the RSTALanguageSupport in Java language completion for method/field completion proposals**.
Beside it has some small fix regarding memory issues and window disposal.