### PR TITLE
Pack tooltip after setting relative location

### DIFF
--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionDescriptionToolTip.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionDescriptionToolTip.java
@@ -10,6 +10,7 @@
 package org.fife.ui.autocomplete;
 
 import java.awt.BorderLayout;
+import java.awt.EventQueue;
 import java.awt.Rectangle;
 import java.awt.Window;
 import javax.swing.BorderFactory;
@@ -134,7 +135,7 @@ class ParameterizedCompletionDescriptionToolTip {
 		}
 
 		tooltip.setLocation(x, y);
-
+		EventQueue.invokeLater(tooltip::pack);
 	}
 
 


### PR DESCRIPTION
Corrects a minor issue, at least on my local system - the parameter description tooltip appears overlapping the actual line I'm editing, until I move to another completion, which ends up triggering `updateText` and a `pack()`, which resizes the window.

Bug:
![tooltip](https://user-images.githubusercontent.com/39345262/72636186-63380900-3913-11ea-9c51-1cf7878312d1.gif)

With this change, the tooltip always (visibly) opens in the 'shrunk' appearance.