### PR TITLE
Add ability to customize a threshold, after which extremely long tool…

### DIFF
--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletion.java
@@ -138,6 +138,11 @@ public class AutoCompletion {
 	private boolean parameterAssistanceEnabled;
 
 	/**
+	 * The maximum length to attempt to display the 'full' parameter description for before truncating.
+	 */
+	private int parameterDescriptionTruncateThreshold = 300;
+
+	/**
 	 * A renderer used for {@link Completion}s in the optional parameter choices
 	 * popup window (displayed when a {@link ParameterizedCompletion} is
 	 * code-completed). If this isn't set, a default renderer is used.
@@ -1277,6 +1282,18 @@ public class AutoCompletion {
 		if (paramChoicesRenderer instanceof JComponent) {
 			((JComponent) paramChoicesRenderer).updateUI();
 		}
+	}
+
+	public int getParameterDescriptionTruncateThreshold() {
+		return parameterDescriptionTruncateThreshold;
+	}
+
+	/**
+	 * Set the maximum number of characters that the {@link ParameterizedCompletionDescriptionToolTip} will attempt to
+	 * display on one line before truncating to a short-form representation.
+	 */
+	public void setParameterDescriptionTruncateThreshold(int truncateThreshold) {
+		this.parameterDescriptionTruncateThreshold = truncateThreshold;
 	}
 
 	/**


### PR DESCRIPTION
…tips will be truncated

Default is 300, which is entirely arbitrary.

Reasoning: I'm implementing a completion provider for a software product. Some of the built in functions have [a lot of](https://docs.inductiveautomation.com/display/DOC80/system.tag.queryTagHistory) parameters - but I can't change the signature of these methods for compatibility reasons.
I _could_ have the individual completions opt out of the descriptive tooltip, but this change allows for a limited presentation that I think is still useful, especially because it maintains the description:

![long_description](https://user-images.githubusercontent.com/39345262/72641966-32120580-3920-11ea-807f-60b4f44201c3.gif)
