### PR TITLE
Add endParam optional attribute to CompletionXMLParser

### DIFF
--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionXMLParser.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionXMLParser.java
@@ -53,6 +53,7 @@ public class CompletionXMLParser extends DefaultHandler {
 	private StringBuilder desc;
 	private String paramName;
 	private String paramType;
+	private boolean endParam;
 	private StringBuilder paramDesc;
 	private List<ParameterizedCompletion.Parameter> params;
 	private String definedIn;
@@ -260,8 +261,7 @@ public class CompletionXMLParser extends DefaultHandler {
 					}
 					else if ("param".equals(qName)) {
 						FunctionCompletion.Parameter param =
-							new FunctionCompletion.Parameter(paramType,
-														paramName);
+							new FunctionCompletion.Parameter(paramType, paramName, endParam);
 						if (paramDesc.length()>0) {
 							param.setDescription(paramDesc.toString());
 							paramDesc.setLength(0);
@@ -407,6 +407,7 @@ public class CompletionXMLParser extends DefaultHandler {
 					if ("param".equals(qName)) {
 						paramName = attrs.getValue("name");
 						paramType = attrs.getValue("type");
+						endParam = Boolean.parseBoolean(attrs.getValue("endParam"));
 						inParam = true;
 					}
 					if (inParam) {

--- a/AutoComplete/src/main/resources/org/fife/ui/autocomplete/CompletionXml.dtd
+++ b/AutoComplete/src/main/resources/org/fife/ui/autocomplete/CompletionXml.dtd
@@ -27,4 +27,5 @@
 <!-- Need to specify at least one of the two attributes below. -->
 <!ATTLIST param
           name       CDATA #IMPLIED
-          type       CDATA #IMPLIED>
+          type       CDATA #IMPLIED
+          endParam   (true|false) "false">


### PR DESCRIPTION
Minor feature. Was working on testing something else, implemented this when I noticed the XML parser didn't support supplying a value for the endParam attribute. Should be NPE-etc safe, and backwards compatible since it defaults to false.