### PR TITLE
Arrow icons customization

### DIFF
--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
@@ -4,6 +4,13 @@
  */
 package org.fife.ui.autocomplete;
 
+import org.fife.ui.rsyntaxtextarea.PopupWindowDecorator;
+
+import javax.swing.*;
+import javax.swing.border.AbstractBorder;
+import javax.swing.border.Border;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.lang.reflect.InvocationTargetException;
@@ -14,26 +21,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.BorderFactory;
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JEditorPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JToolBar;
-import javax.swing.JWindow;
-import javax.swing.SwingUtilities;
-import javax.swing.Timer;
-import javax.swing.UIManager;
-import javax.swing.border.AbstractBorder;
-import javax.swing.border.Border;
-import javax.swing.event.HyperlinkEvent;
-import javax.swing.event.HyperlinkListener;
-
-import org.fife.ui.rsyntaxtextarea.PopupWindowDecorator;
 
 
 /**
@@ -578,23 +565,39 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 	class ToolBarBackAction extends AbstractAction {
 
 		ToolBarBackAction(boolean ltr) {
-			String img = "org/fife/ui/autocomplete/arrow_" +
-						(ltr ? "left.png" : "right.png");
-			ClassLoader cl = getClass().getClassLoader();
-			Icon icon = new ImageIcon(cl.getResource(img));
+			setIcon(ltr);
+
+			UIManager.addPropertyChangeListener(evt -> {
+				if (evt.getPropertyName().equals("lookAndFeel")) {
+					setIcon(ltr);
+				}
+			});
+		}
+
+		private void setIcon(boolean ltr) {
+			Icon icon = UIManager.getIcon("autocomplete.leftArrow");
+
+			if (icon == null) {
+				if (ltr)
+					icon = new ImageIcon(getClass().getResource("arrow_left.png"));
+				else
+					icon = new ImageIcon(getClass().getResource("arrow_right.png"));
+
+				UIManager.put("autocomplete.leftArrow", icon);
+			}
+
 			putValue(Action.SMALL_ICON, icon);
 		}
 
 		@Override
 		public void actionPerformed(ActionEvent e) {
-			if (historyPos>0) {
+			if (historyPos > 0) {
 				HistoryEntry pair = history.get(--historyPos);
 				descArea.setText(pair.summary);
-				if (pair.anchor!=null) {
+				if (pair.anchor != null) {
 					//System.out.println("Scrolling to: " + pair.anchor);
 					descArea.scrollToReference(pair.anchor);
-				}
-				else {
+				} else {
 					descArea.setCaretPosition(0);
 				}
 				setActionStates();
@@ -610,23 +613,39 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 	class ToolBarForwardAction extends AbstractAction {
 
 		ToolBarForwardAction(boolean ltr) {
-			String img = "org/fife/ui/autocomplete/arrow_" +
-							(ltr ? "right.png" : "left.png");
-			ClassLoader cl = getClass().getClassLoader();
-			Icon icon = new ImageIcon(cl.getResource(img));
+			setIcon(ltr);
+
+			UIManager.addPropertyChangeListener(evt -> {
+				if (evt.getPropertyName().equals("lookAndFeel")) {
+					setIcon(ltr);
+				}
+			});
+		}
+
+		void setIcon(boolean ltr) {
+			Icon icon = UIManager.getIcon("autocomplete.rightArrow");
+
+			if (icon == null) {
+				if (ltr)
+					icon = new ImageIcon(getClass().getResource("arrow_right.png"));
+				else
+					icon = new ImageIcon(getClass().getResource("arrow_left.png"));
+
+				UIManager.put("autocomplete.rightArrow", icon);
+			}
+
 			putValue(Action.SMALL_ICON, icon);
 		}
 
 		@Override
 		public void actionPerformed(ActionEvent e) {
-			if (history!=null && historyPos<history.size()-1) {
+			if (history != null && historyPos < history.size() - 1) {
 				HistoryEntry pair = history.get(++historyPos);
 				descArea.setText(pair.summary);
-				if (pair.anchor!=null) {
+				if (pair.anchor != null) {
 					//System.out.println("Scrolling to: " + pair.anchor);
 					descArea.scrollToReference(pair.anchor);
-				}
-				else {
+				} else {
 					descArea.setCaretPosition(0);
 				}
 				setActionStates();

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
@@ -4,13 +4,6 @@
  */
 package org.fife.ui.autocomplete;
 
-import org.fife.ui.rsyntaxtextarea.PopupWindowDecorator;
-
-import javax.swing.*;
-import javax.swing.border.AbstractBorder;
-import javax.swing.border.Border;
-import javax.swing.event.HyperlinkEvent;
-import javax.swing.event.HyperlinkListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.lang.reflect.InvocationTargetException;
@@ -21,6 +14,26 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.BorderFactory;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JEditorPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JToolBar;
+import javax.swing.JWindow;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import javax.swing.UIManager;
+import javax.swing.border.AbstractBorder;
+import javax.swing.border.Border;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkListener;
+
+import org.fife.ui.rsyntaxtextarea.PopupWindowDecorator;
 
 import static java.util.Objects.requireNonNull;
 
@@ -58,12 +71,12 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 	/**
 	 * Action that goes to the previous description displayed.
 	 */
-	private final Action backAction;
+	private Action backAction;
 
 	/**
 	 * Action that goes to the next description displayed.
 	 */
-	private final Action forwardAction;
+	private Action forwardAction;
 
 	/**
 	 * History of descriptions displayed.
@@ -535,7 +548,9 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 			} else {
 				action.putValue(Action.SMALL_ICON, leftIcon);
 			}
-		} else throw new IllegalArgumentException();
+		} else {
+			throw new IllegalArgumentException();
+		}
 	}
 
 
@@ -549,7 +564,7 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 		private String anchor;
 
 		HistoryEntry(Completion completion, String summary,
-					 String anchor) {
+									String anchor) {
 			this.completion = completion;
 			this.summary = summary;
 			this.anchor = anchor;
@@ -645,6 +660,7 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 				setActionStates();
 			}
 		}
+
 	}
 
 

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
@@ -520,7 +520,7 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 		if (rightIcon == null) {
 			URL rightIc = AutoCompleteDescWindow.class.getResource("arrow_right.png");
 			rightIcon = new ImageIcon(requireNonNull(rightIc));
-			UIManager.put("autocomplete.leftArrow", leftIcon);
+			UIManager.put("autocomplete.rightArrow", leftIcon);
 		}
 
 		if ("back".equals(type)) {

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
@@ -35,8 +35,6 @@ import javax.swing.event.HyperlinkListener;
 
 import org.fife.ui.rsyntaxtextarea.PopupWindowDecorator;
 
-import static java.util.Objects.requireNonNull;
-
 
 /**
  * The optional "description" window that describes the currently selected
@@ -520,37 +518,40 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 		setArrowIcon(backAction, orientation.isLeftToRight(), "back");
 	}
 
+	/**
+	 * Sets the appropriate arrow icon for the specified navigation action based on
+	 * the component orientation (Left-to-Right or Right-to-Left) and action type.
+	 * <p>
+	 * This method first checks the {@link UIManager} for a custom icon registered under
+	 * the semantic key. If absent, it loads the default icon resource from the classpath,
+	 * caches it in the {@link UIManager} for future use, and assigns it to the action.
+	 *
+	 * @param action the menu or toolbar action to update with the icon
+	 * @param ltr    {@code true} if the component orientation is Left-to-Right; {@code false} for Right-to-Left
+	 * @param type   the type of navigation action, either {@code "back"} or {@code "forward"}
+	 */
 	private static void setArrowIcon(Action action, boolean ltr, String type) {
-		Icon leftIcon = UIManager.getIcon("autocomplete.leftArrow");
-		Icon rightIcon = UIManager.getIcon("autocomplete.rightArrow");
+		// Determine the UIManager key based on action type and text direction
+		String key = "back".equals(type) ?
+			(ltr ? "autocomplete.descWindow.backIcon" : "autocomplete.descWindow.forwardIcon") :
+			(ltr ? "autocomplete.descWindow.forwardIcon" : "autocomplete.descWindow.backIcon");
 
-		if (leftIcon == null) {
-			URL leftIc = AutoCompleteDescWindow.class.getResource("arrow_left.png");
-			leftIcon = new ImageIcon(requireNonNull(leftIc));
-			UIManager.put("autocomplete.leftArrow", leftIcon);
-		}
+		Icon icon = UIManager.getIcon(key);
 
-		if (rightIcon == null) {
-			URL rightIc = AutoCompleteDescWindow.class.getResource("arrow_right.png");
-			rightIcon = new ImageIcon(requireNonNull(rightIc));
-			UIManager.put("autocomplete.rightArrow", rightIcon);
-		}
+		if (icon == null) {
+			// Fallback to default classpath resources if not defined in UIManager
+			String resourceName = key.endsWith("backIcon") ? "arrow_left.png" : "arrow_right.png";
+			URL url = AutoCompleteDescWindow.class.getResource(resourceName);
 
-		if ("back".equals(type)) {
-			if (ltr) {
-				action.putValue(Action.SMALL_ICON, leftIcon);
+			if (url != null) {
+				icon = new ImageIcon(url);
+				UIManager.put(key, icon);
 			} else {
-				action.putValue(Action.SMALL_ICON, rightIcon);
+				throw new IllegalArgumentException("Icon resource not found on classpath: " + resourceName);
 			}
-		} else if ("forward".equals(type)) {
-			if (ltr) {
-				action.putValue(Action.SMALL_ICON, rightIcon);
-			} else {
-				action.putValue(Action.SMALL_ICON, leftIcon);
-			}
-		} else {
-			throw new IllegalArgumentException();
 		}
+
+		action.putValue(Action.SMALL_ICON, icon);
 	}
 
 

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
@@ -58,12 +58,12 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 	/**
 	 * Action that goes to the previous description displayed.
 	 */
-	private Action backAction;
+	private final Action backAction;
 
 	/**
 	 * Action that goes to the next description displayed.
 	 */
-	private Action forwardAction;
+	private final Action forwardAction;
 
 	/**
 	 * History of descriptions displayed.
@@ -503,26 +503,25 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 		((JPanel) getContentPane()).setBorder(TipUtil.getToolTipBorder());
 
 		ComponentOrientation orientation = ac.getTextComponentOrientation();
-		setIcon(forwardAction, orientation.isLeftToRight(), "forward");
-		setIcon(backAction, orientation.isLeftToRight(), "back");
+		setArrowIcon(forwardAction, orientation.isLeftToRight(), "forward");
+		setArrowIcon(backAction, orientation.isLeftToRight(), "back");
 	}
 
-	private static void setIcon(Action action, boolean ltr, String type) {
+	private static void setArrowIcon(Action action, boolean ltr, String type) {
 		Icon leftIcon = UIManager.getIcon("autocomplete.leftArrow");
 		Icon rightIcon = UIManager.getIcon("autocomplete.rightArrow");
 
 		if (leftIcon == null) {
-			String leftIc = ltr ? "arrow_left.png" : "arrow_right.png";
-			leftIcon = new ImageIcon(requireNonNull(AutoCompleteDescWindow.class.getResource(leftIc)));
+			URL leftIc = AutoCompleteDescWindow.class.getResource("arrow_left.png");
+			leftIcon = new ImageIcon(requireNonNull(leftIc));
 			UIManager.put("autocomplete.leftArrow", leftIcon);
 		}
 
 		if (rightIcon == null) {
-			String rightIc = ltr ? "arrow_right.png" : "arrow_left.png";
-			rightIcon = new ImageIcon(requireNonNull(AutoCompleteDescWindow.class.getResource(rightIc)));
+			URL rightIc = AutoCompleteDescWindow.class.getResource("arrow_right.png");
+			rightIcon = new ImageIcon(requireNonNull(rightIc));
 			UIManager.put("autocomplete.leftArrow", leftIcon);
 		}
-
 
 		if ("back".equals(type)) {
 			if (ltr) {
@@ -536,7 +535,7 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 			} else {
 				action.putValue(Action.SMALL_ICON, leftIcon);
 			}
-		}
+		} else throw new IllegalArgumentException();
 	}
 
 
@@ -603,7 +602,7 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 	class ToolBarBackAction extends AbstractAction {
 
 		ToolBarBackAction(boolean ltr) {
-			setIcon(this, ltr, "back");
+			setArrowIcon(this, ltr, "back");
 		}
 
 		@Override
@@ -629,7 +628,7 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 	class ToolBarForwardAction extends AbstractAction {
 
 		ToolBarForwardAction(boolean ltr) {
-			setIcon(this, ltr, "forward");
+			setArrowIcon(this, ltr, "forward");
 		}
 
 		@Override

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 
+import static java.util.Objects.requireNonNull;
+
 
 /**
  * The optional "description" window that describes the currently selected
@@ -498,7 +500,43 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 		TipUtil.tweakTipEditorPane(descArea);
 		scrollPane.setBackground(descArea.getBackground());
 		scrollPane.getViewport().setBackground(descArea.getBackground());
-		((JPanel)getContentPane()).setBorder(TipUtil.getToolTipBorder());
+		((JPanel) getContentPane()).setBorder(TipUtil.getToolTipBorder());
+
+		ComponentOrientation orientation = ac.getTextComponentOrientation();
+		setIcon(forwardAction, orientation.isLeftToRight(), "forward");
+		setIcon(backAction, orientation.isLeftToRight(), "back");
+	}
+
+	private static void setIcon(Action action, boolean ltr, String type) {
+		Icon leftIcon = UIManager.getIcon("autocomplete.leftArrow");
+		Icon rightIcon = UIManager.getIcon("autocomplete.rightArrow");
+
+		if (leftIcon == null) {
+			String leftIc = ltr ? "arrow_left.png" : "arrow_right.png";
+			leftIcon = new ImageIcon(requireNonNull(AutoCompleteDescWindow.class.getResource(leftIc)));
+			UIManager.put("autocomplete.leftArrow", leftIcon);
+		}
+
+		if (rightIcon == null) {
+			String rightIc = ltr ? "arrow_right.png" : "arrow_left.png";
+			rightIcon = new ImageIcon(requireNonNull(AutoCompleteDescWindow.class.getResource(rightIc)));
+			UIManager.put("autocomplete.leftArrow", leftIcon);
+		}
+
+
+		if ("back".equals(type)) {
+			if (ltr) {
+				action.putValue(Action.SMALL_ICON, leftIcon);
+			} else {
+				action.putValue(Action.SMALL_ICON, rightIcon);
+			}
+		} else if ("forward".equals(type)) {
+			if (ltr) {
+				action.putValue(Action.SMALL_ICON, rightIcon);
+			} else {
+				action.putValue(Action.SMALL_ICON, leftIcon);
+			}
+		}
 	}
 
 
@@ -512,7 +550,7 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 		private String anchor;
 
 		HistoryEntry(Completion completion, String summary,
-									String anchor) {
+					 String anchor) {
 			this.completion = completion;
 			this.summary = summary;
 			this.anchor = anchor;
@@ -565,28 +603,7 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 	class ToolBarBackAction extends AbstractAction {
 
 		ToolBarBackAction(boolean ltr) {
-			setIcon(ltr);
-
-			UIManager.addPropertyChangeListener(evt -> {
-				if (evt.getPropertyName().equals("lookAndFeel")) {
-					setIcon(ltr);
-				}
-			});
-		}
-
-		private void setIcon(boolean ltr) {
-			Icon icon = UIManager.getIcon("autocomplete.leftArrow");
-
-			if (icon == null) {
-				if (ltr)
-					icon = new ImageIcon(getClass().getResource("arrow_left.png"));
-				else
-					icon = new ImageIcon(getClass().getResource("arrow_right.png"));
-
-				UIManager.put("autocomplete.leftArrow", icon);
-			}
-
-			putValue(Action.SMALL_ICON, icon);
+			setIcon(this, ltr, "back");
 		}
 
 		@Override
@@ -603,7 +620,6 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 				setActionStates();
 			}
 		}
-
 	}
 
 
@@ -613,28 +629,7 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 	class ToolBarForwardAction extends AbstractAction {
 
 		ToolBarForwardAction(boolean ltr) {
-			setIcon(ltr);
-
-			UIManager.addPropertyChangeListener(evt -> {
-				if (evt.getPropertyName().equals("lookAndFeel")) {
-					setIcon(ltr);
-				}
-			});
-		}
-
-		void setIcon(boolean ltr) {
-			Icon icon = UIManager.getIcon("autocomplete.rightArrow");
-
-			if (icon == null) {
-				if (ltr)
-					icon = new ImageIcon(getClass().getResource("arrow_right.png"));
-				else
-					icon = new ImageIcon(getClass().getResource("arrow_left.png"));
-
-				UIManager.put("autocomplete.rightArrow", icon);
-			}
-
-			putValue(Action.SMALL_ICON, icon);
+			setIcon(this, ltr, "forward");
 		}
 
 		@Override
@@ -651,7 +646,6 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 				setActionStates();
 			}
 		}
-
 	}
 
 

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
@@ -520,7 +520,7 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 		if (rightIcon == null) {
 			URL rightIc = AutoCompleteDescWindow.class.getResource("arrow_right.png");
 			rightIcon = new ImageIcon(requireNonNull(rightIc));
-			UIManager.put("autocomplete.rightArrow", leftIcon);
+			UIManager.put("autocomplete.rightArrow", rightIcon);
 		}
 
 		if ("back".equals(type)) {


### PR DESCRIPTION
It would be nice to have a way to change the icons appearing in the description window.
In may case, I'm using FlatLaf and I prefer to change the default icons of the `AutoCompleteDescWindow` with other flat icons.
Currently I didn't find any solution, since also `backAction` and `forwardAction` are private fields, and so subclass `AutoCompleteDescWindow` it's not helpful.

I propose to search for the icons into the `UIManager`, so that one can customize them simply through `UIManager.put("autocomplete.leftArrow", icon)` and `UIManager.put("autocomplete.rightArrow", icon)`.

During initialization, `ToolBarForwardAction` and `ToolBarBakcAction` search for custom icons and, if not found, use the default currently provided by the library.