### PR TITLE
Fix problem of ExternalURLHandler blocking selection of completion names

### DIFF
--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
@@ -346,24 +346,22 @@ class AutoCompleteDescWindow extends JWindow implements HyperlinkListener,
 							newUrl, e.getDescription(), e.getSourceElement());
 				}
 			}
-		}
 
-		// Custom hyperlink handler for this completion type
-		ExternalURLHandler handler = ac.getExternalURLHandler();
-		if (handler!=null) {
-			HistoryEntry current = history.get(historyPos);
-			handler.urlClicked(e, current.completion, this);
-			return;
-		}
-
-		// No custom handler...
-		if (url!=null) {
+			// Custom hyperlink handler for this completion type
+			ExternalURLHandler handler = ac.getExternalURLHandler();
+			if (handler!=null) {
+				HistoryEntry current = history.get(historyPos);
+				handler.urlClicked(e, current.completion, this);
+			}
+			else {
+			// No custom handler...
 			// Try loading in external browser (Java 6+ only).
-			try {
-				Util.browse(new URI(url.toString()));
-			} catch (/*IO*/URISyntaxException ioe) {
-				UIManager.getLookAndFeel().provideErrorFeedback(descArea);
-				ioe.printStackTrace();
+				try {
+					Util.browse(new URI(url.toString()));
+				} catch (/*IO*/URISyntaxException ioe) {
+					UIManager.getLookAndFeel().provideErrorFeedback(descArea);
+					ioe.printStackTrace();
+				}
 			}
 		}
 		else { // Assume simple function name text, like in c.xml


### PR DESCRIPTION
Previously, in an ExternalURLHandler was present it would be unconditionally invoked even if no URL was present in the HyperLinkEvent.  When local link names are clicked on there is no URL,, just name in the  HyperLinkEvent description, so it ends up that local names are not being processed.

With this change the ExternalURLHandler is only  invoked when there is a URL to handle.