### PR TITLE
refactor: use uppercase Color constants instead of deprecated lowercase ones

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,50 @@
+# Create a Pull Request
+
+Create a branch (if needed), commit staged/unstaged changes, push, and open/update a PR.
+
+## Steps
+
+1. **Check branch status**: Run `git status` and `git branch --show-current`
+   - If on `master` or `main`, create a new branch:
+     - Analyze the changes to determine a descriptive branch name
+     - Use lower-kebab-case (e.g., `add-user-authentication`, `fix-login-bug`)
+     - Run `git checkout -b <branch-name>`
+   - If already on a feature branch, continue on that branch
+
+2. **Ensure JDK 25 is on the path**. This library requires JDK 25 or later to build.
+   Ensure that `java --version` shows `25` or later. If not, search for Java 25 in common
+   locaitons for the operating system. If you can't find it, exit early.
+
+3. **Build locally** by running `./gradlew clean build`. If there are any checkstyle
+   or spotbugs failure, or javac errors, fix them and rerun this check to verify your changes.
+   Don't worry about javac warnings currently - there are 3 that we need to address later,
+   but for now can be ignored.
+
+4. **Review changes**: Run `git status` and `git diff` to understand what will be committed
+
+5. **Stage and commit**:
+   - Stage relevant files (prefer specific files over `git add -A`)
+   - Determine the commit strategy:
+     - If the feature branch has no prior commits: create a new commit
+     - If the feature branch has a prior commit and a draft PR exists (`gh pr view --json isDraft`): amend the existing commit (`git commit --amend`)
+     - If the feature branch has a prior commit and no PR exists, or the PR is not in draft: create a new commit
+   - Write a commit message (or update the existing one if needed) using the [conventional commit style](https://www.conventionalcommits.org/en/v1.0.0/)
+     - Don't read the conventional commit site/URL if you already know the style
+     - Use "!" after the type to indicate a breaking change
+     - Use "build(deps)" for dependency bumps
+   - Include `Co-Authored-By: Claude <noreply@anthropic.com>` in the commit message
+
+6. **Push**:
+   - If the commit was amended: `git push --force-with-lease`
+   - Otherwise: `git push -u origin <branch-name>`
+
+7. **Create or update PR**:
+   - Check if a PR already exists for this branch with `gh pr view`
+   - If no PR exists: use `gh pr create --draft` with the title, body, and labels below
+   - If a PR exists: use `gh pr edit` to update the title, body, and labels
+   - Title: concise, matching the commit style
+   - Body: formatted using this repo's PR template (`.github/PULL_REQUEST_TEMPLATE.md`),
+     with an additional footer: `🤖 Generated with [Claude Code](https://claude.ai/claude-code)`
+   - Labels — add any that are relevant:
+     - `bug`, `build`, `ci/cd`, `code-folding`, dependencies`, `enhancement`, `refactor`, `sytax-highlighting`
+     - Only add a `tests` label if the PR is *only* adding test coverage

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletionStyleContext.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletionStyleContext.java
@@ -42,7 +42,7 @@ public class AutoCompletionStyleContext {
 	 * Constructor.
 	 */
 	public AutoCompletionStyleContext() {
-		setParameterOutlineColor(Color.gray);
+		setParameterOutlineColor(Color.GRAY);
 		setParameterCopyColor(new Color(0xb4d7ff));
 		setParameterizedCompletionCursorPositionColor(new Color(0x00b400));
 	}

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/TipUtil.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/TipUtil.java
@@ -89,7 +89,7 @@ final class TipUtil {
 
 	/**
 	 * Returns the color to use for hyperlink-style components in tool tips.
-	 * This method will return <code>Color.blue</code> unless it appears
+	 * This method will return <code>Color.BLUE</code> unless it appears
 	 * that the current LookAndFeel uses light text on a dark background,
 	 * in which case a brighter alternative is returned.
 	 *
@@ -105,7 +105,7 @@ final class TipUtil {
 			fg = new JToolTip().getForeground();
 		}
 
-		return Util.isLightForeground(fg) ? Util.LIGHT_HYPERLINK_FG : Color.blue;
+		return Util.isLightForeground(fg) ? Util.LIGHT_HYPERLINK_FG : Color.BLUE;
 
 	}
 

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/Util.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/Util.java
@@ -122,7 +122,7 @@ public final class Util {
 
 	/**
 	 * Returns the color to use for hyperlink-style components.  This method
-	 * will return <code>Color.blue</code> unless it appears that the current
+	 * will return <code>Color.BLUE</code> unless it appears that the current
 	 * LookAndFeel uses light text on a dark background, in which case a
 	 * brighter alternative is returned.
 	 *
@@ -138,7 +138,7 @@ public final class Util {
 			fg = new JLabel().getForeground();
 		}
 
-		return isLightForeground(fg) ? LIGHT_HYPERLINK_FG : Color.blue;
+		return isLightForeground(fg) ? LIGHT_HYPERLINK_FG : Color.BLUE;
 
 	}
 


### PR DESCRIPTION
## Summary
- Replace deprecated lowercase `Color.gray`/`Color.blue` constants with their uppercase equivalents (`Color.GRAY`/`Color.BLUE`) in `AutoCompletionStyleContext`, `TipUtil`, and `Util`
- Add a `/pr` slash command for creating pull requests via Claude Code

## Test plan
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, tests all green)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)