### PR TITLE
build(deps): bump checkstyle, spotbugs, and bnd plugin versions

### DIFF
--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/DefaultCompletionProvider.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/DefaultCompletionProvider.java
@@ -294,6 +294,31 @@ public class DefaultCompletionProvider extends AbstractCompletionProvider {
 
 
 	/**
+	 * Loads completions from an XML file.  The XML should validate against
+	 * <code>CompletionXml.dtd</code>.
+	 *
+	 * @param resource A resource the current ClassLoader can get to.
+	 * @throws IOException If an IO error occurs.
+	 */
+	public void loadFromXML(String resource) throws IOException {
+		ClassLoader cl = getClass().getClassLoader();
+		InputStream in = cl.getResourceAsStream(resource);
+		if (in==null) {
+			File file = new File(resource);
+			if (file.isFile()) {
+				in = Files.newInputStream(file.toPath());
+			}
+			else {
+				throw new IOException("No such resource: " + resource);
+			}
+		}
+		try (BufferedInputStream bin = new BufferedInputStream(in)) {
+			loadFromXML(bin);
+		}
+	}
+
+
+	/**
 	 * Loads completions from an XML input stream.  The XML should validate
 	 * against <code>CompletionXml.dtd</code>.
 	 *
@@ -327,31 +352,6 @@ public class DefaultCompletionProvider extends AbstractCompletionProvider {
 			throw new IOException(e.toString());
 		}
 
-	}
-
-
-	/**
-	 * Loads completions from an XML file.  The XML should validate against
-	 * <code>CompletionXml.dtd</code>.
-	 *
-	 * @param resource A resource the current ClassLoader can get to.
-	 * @throws IOException If an IO error occurs.
-	 */
-	public void loadFromXML(String resource) throws IOException {
-		ClassLoader cl = getClass().getClassLoader();
-		InputStream in = cl.getResourceAsStream(resource);
-		if (in==null) {
-			File file = new File(resource);
-			if (file.isFile()) {
-				in = Files.newInputStream(file.toPath());
-			}
-			else {
-				throw new IOException("No such resource: " + resource);
-			}
-		}
-		try (BufferedInputStream bin = new BufferedInputStream(in)) {
-			loadFromXML(bin);
-		}
 	}
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,12 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:7.2.0'
+        classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:7.3.0'
     }
 }
 
 plugins {
-    id 'com.github.spotbugs' version '6.4.8'
+    id 'com.github.spotbugs' version '6.5.9'
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
@@ -50,7 +50,7 @@ subprojects {
     }
 
     checkstyle {
-        toolVersion = '12.3.0'
+        toolVersion = '13.8.0'
         configDirectory = file("$rootProject.projectDir/config/checkstyle")
     }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -83,6 +83,12 @@
         <property name="maximum" value="0"/>
         <property name="message" value="Line has trailing spaces."/>
     </module>
+<!--    <module name="RegexpSingleline">-->
+<!--        <property name="format" value="(?&lt;!//)\s*System\.(?:out|err)\.println\("/>-->
+<!--        <property name="minimum" value="0"/>-->
+<!--        <property name="maximum" value="0"/>-->
+<!--        <property name="message" value="Do not use System.out.println or System.err.println"/>-->
+<!--    </module>-->
 
     <!-- Checks for Headers                                               -->
     <!-- See https://checkstyle.sourceforge.io/checks/header/index.html   -->
@@ -183,7 +189,15 @@
                 LITERAL_FINALLY, LITERAL_CATCH, DO_WHILE, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY,
                 LITERAL_CASE, LAMBDA, LITERAL_WHEN"/>
         </module>
-        <!--<module name="WhitespaceAround"/>-->
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <!-- Don't check around boolean comparators as old code didn't follow this convention for them. -->
+            <property name="tokens" value="LCURLY, LITERAL_IF, LITERAL_ELSE, LITERAL_WHILE, LITERAL_DO, LITERAL_FOR,
+                LITERAL_FINALLY, LITERAL_CATCH, DO_WHILE, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY,
+                LAMBDA, LITERAL_WHEN"/>
+        </module>
 
 
         <!-- Modifier Checks                                            -->
@@ -221,22 +235,28 @@
         -->
         <!--        <module name="IllegalCatch"/>-->
         <module name="IllegalInstantiation"/>
+        <module name="IllegalSymbol"/>
         <module name="IllegalThrows"/>
         <module name="IllegalType"/>
         <!--<module name="InnerAssignment"/> -->
         <!--<module name="MagicNumber"/> Unfortunately, too much noise -->
         <!--<module name="MissingSwitchDefault"/>-->
         <module name="MultipleVariableDeclarations"/>
+        <module name="OverloadMethodsDeclarationOrder">
+            <property name="orderByIncreasingParameterCount" value="true" />
+        </module>
         <module name="PatternVariableAssignment"/>
         <module name="SimplifyBooleanExpression"/>
-        <module name="UnnecessaryNullCheckWithInstanceOf"/>
         <module name="SimplifyBooleanReturn"/>
+        <module name="UnnecessaryNullCheckWithInstanceOf"/>
         <!--        <module name="UnnecessaryParentheses"/>-->
         <module name="UnnecessarySemicolonAfterOuterTypeDeclaration"/>
         <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/>
         <module name="UnnecessarySemicolonInEnumeration"/>
         <module name="UnnecessarySemicolonInTryWithResources"/>
         <module name="UnusedLocalVariable"/>
+        <module name="UnusedTryResourceShouldBeUnnamed"/>
+        <!--<module name="UseEnhancedSwitch"/> - TODO: too noisy for now -->
 
         <!-- Checks for class design                                        -->
         <!-- See https://checkstyle.sourceforge.io/checks/design/index.html -->
@@ -256,6 +276,7 @@
         <module name="AvoidEscapedUnicodeCharacters"/>
         <module name="CommentsIndentation"/>
         <!--<module name="FinalParameters"/>-->
+        <module name="NumericalPrefixesInfixesSuffixesCharacterCase"/>
         <!-- <module name="TodoComment"/> -->
         <module name="UpperEll"/>
 


### PR DESCRIPTION
## Summary
- Bumps checkstyle `12.3.0` -> `13.8.0`, spotbugs plugin `6.4.8` -> `6.5.9`, and bnd plugin `7.2.0` -> `7.3.0`
- Enables new checkstyle checks available in the newer version (`OverloadMethodsDeclarationOrder`, `IllegalSymbol`, `UnusedTryResourceShouldBeUnnamed`, `NumericalPrefixesInfixesSuffixesCharacterCase`, `WhitespaceAround`)
- Reorders an overloaded method in `DefaultCompletionProvider` to satisfy the new `OverloadMethodsDeclarationOrder` check

## Test plan
- [x] `./gradlew clean build` passes (compile, checkstyle, spotbugs, tests) on JDK 25

🤖 Generated with [Claude Code](https://claude.ai/claude-code)