### PR TITLE
refactor: minor code cleanups and fix typos

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -13,7 +13,7 @@ Create a branch (if needed), commit staged/unstaged changes, push, and open/upda
 
 2. **Ensure JDK 25 is on the path**. This library requires JDK 25 or later to build.
    Ensure that `java --version` shows `25` or later. If not, search for Java 25 in common
-   locaitons for the operating system. If you can't find it, exit early.
+   locations for the operating system. If you can't find it, exit early.
 
 3. **Build locally** by running `./gradlew clean build`. If there are any checkstyle
    or spotbugs failure, or javac errors, fix them and rerun this check to verify your changes.

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletePopupWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletePopupWindow.java
@@ -308,7 +308,7 @@ class AutoCompletePopupWindow extends JWindow implements CaretListener,
 	 * @return The default list cell renderer.
 	 * @see #setListCellRenderer(ListCellRenderer)
 	 */
-	public ListCellRenderer getListCellRenderer() {
+	public ListCellRenderer<Object> getListCellRenderer() {
 		DelegatingCellRenderer dcr = (DelegatingCellRenderer)list.
 															getCellRenderer();
 		return dcr.getFallbackCellRenderer();

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletion.java
@@ -13,6 +13,7 @@ import java.awt.event.*;
 import java.awt.geom.Rectangle2D;
 import java.beans.*;
 import java.util.List;
+import java.util.Objects;
 import javax.swing.*;
 import javax.swing.event.*;
 import javax.swing.text.*;
@@ -425,7 +426,7 @@ public class AutoCompletion {
 	 * @return The default list cell renderer.
 	 * @see #setListCellRenderer(ListCellRenderer)
 	 */
-	public ListCellRenderer getListCellRenderer() {
+	public ListCellRenderer<Object> getListCellRenderer() {
 		return renderer;
 	}
 
@@ -978,10 +979,7 @@ public class AutoCompletion {
 	 *         <code>null</code>.
 	 */
 	public void setCompletionProvider(CompletionProvider provider) {
-		if (provider == null) {
-			throw new IllegalArgumentException("provider cannot be null");
-		}
-		this.provider = provider;
+		this.provider = Objects.requireNonNull(provider, "provider cannot be null");
 		if (isHideOnCompletionProviderChange()) {
 			hidePopupWindow(); // In case new choices should be displayed.
 		}
@@ -1165,14 +1163,11 @@ public class AutoCompletion {
 	 * Sets the keystroke that should be used to trigger the auto-complete popup
 	 * window.
 	 *
-	 * @param ks The keystroke.
-	 * @throws IllegalArgumentException If <code>ks</code> is <code>null</code>.
+	 * @param ks The keystroke. This cannot be {@code null}.
 	 * @see #getTriggerKey()
 	 */
 	public void setTriggerKey(KeyStroke ks) {
-		if (ks == null) {
-			throw new IllegalArgumentException("trigger key cannot be null");
-		}
+		Objects.requireNonNull(ks, "trigger key cannot be null");
 		if (!ks.equals(trigger)) {
 			if (textComponent != null) {
 				// Put old trigger action back.

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/FastListUI.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/FastListUI.java
@@ -141,10 +141,9 @@ class FastListUI extends BasicListUI {
 	 * completions.
 	 */
 	@Override
-	@SuppressWarnings("unchecked") // BasicListUI has unparameterized JList
 	protected void updateLayoutState() {
 
-		ListModel<?> model = list.getModel();
+		ListModel<Object> model = list.getModel();
 		int itemCount = model.getSize();
 
 		// If the item count is small enough to run fast on practically all
@@ -157,7 +156,7 @@ class FastListUI extends BasicListUI {
 
 		// Otherwise, assume all cells are the same height as the first cell,
 		// and estimate the necessary width.
-		ListCellRenderer<Object> renderer = (ListCellRenderer<Object>)list.getCellRenderer();
+		ListCellRenderer<Object> renderer = list.getCellRenderer();
 
 		cellWidth = list.getWidth();
 		if (list.getParent() instanceof JViewport) { // Always true for us

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/LanguageAwareCompletionProvider.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/LanguageAwareCompletionProvider.java
@@ -13,6 +13,7 @@ import java.awt.Point;
 import java.awt.event.MouseEvent;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import javax.swing.text.JTextComponent;
 
 import org.fife.ui.rsyntaxtextarea.RSyntaxDocument;
@@ -332,10 +333,7 @@ public class LanguageAwareCompletionProvider extends CompletionProviderBase
 	 * @see #getDefaultCompletionProvider()
 	 */
 	public void setDefaultCompletionProvider(CompletionProvider provider) {
-		if (provider==null) {
-			throw new IllegalArgumentException("provider cannot be null");
-		}
-		this.defaultProvider = provider;
+		this.defaultProvider = Objects.requireNonNull(provider, "provider cannot be null");
 	}
 
 

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/OutlineHighlightPainter.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/OutlineHighlightPainter.java
@@ -13,6 +13,7 @@ import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.Shape;
+import java.util.Objects;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultHighlighter;
 import javax.swing.text.JTextComponent;
@@ -130,10 +131,7 @@ class OutlineHighlightPainter extends
 	 * @see #getColor()
 	 */
 	public void setColor(Color color) {
-		if (color==null) {
-			throw new IllegalArgumentException("color cannot be null");
-		}
-		this.color = color;
+		this.color = Objects.requireNonNull(color, "color cannot be null");
 	}
 
 

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/TemplateCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/TemplateCompletion.java
@@ -369,11 +369,7 @@ public class TemplateCompletion extends AbstractCompletion
 				}
 			}
 
-			StringBuilder sb2 = new StringBuilder();
-			for (int i = 0; i < size; i++) {
-				sb2.append(' ');
-			}
-			String tabStr = sb2.toString();
+			String tabStr = " ".repeat(Math.max(0, size));
 
 			int lastOffs = 0;
 			do {

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SNAPSHOT builds of the in-development, unreleased version are hosted on
 [Sonatype](https://oss.sonatype.org/content/repositories/snapshots/com/fifesoft/autocomplete/).
 
 # Compiling
-AutoComplete is built using Gradle. It requires Java 17 to buil but runs on
+AutoComplete is built using Gradle. It requires Java 17 to build but runs on
 Java 8 or later.
 To compile the source, run all tests, and build the distribution jar,
 simply run the following gradle command:


### PR DESCRIPTION
## Summary
- Use proper generics for `ListCellRenderer`/`ListModel` instead of raw types (removing a `@SuppressWarnings("unchecked")`)
- Replace manual null checks with `Objects.requireNonNull`
- Replace manual `StringBuilder` loop with `String.repeat`
- Fix typos in `README.md` and `.claude/commands/pr.md`

## Test plan
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, tests all green)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)