### PR TITLE
refactor: simplify Java license file headers

### DIFF
--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AbstractCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AbstractCompletion.java
@@ -1,8 +1,4 @@
 /*
- * 12/21/2008
- *
- * AbstractCompletion.java - Base class for possible completions.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AbstractCompletionProvider.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AbstractCompletionProvider.java
@@ -1,8 +1,4 @@
 /*
- * 12/21/2008
- *
- * AbstractCompletionProvider.java - Base class for completion providers.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompleteDescWindow.java
@@ -1,9 +1,4 @@
 /*
- * 12/21/2008
- *
- * AutoCompleteDescWindow.java - A window containing a description of the
- * currently selected completion.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletePopupWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletePopupWindow.java
@@ -1,9 +1,4 @@
 /*
- * 12/21/2008
- *
- * AutoCompletePopupWindow.java - A window containing a list of auto-complete
- * choices.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletion.java
@@ -1,8 +1,4 @@
 /*
- * 12/21/2008
- *
- * AutoCompletion.java - Handles auto-completion for a text component.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletionEvent.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletionEvent.java
@@ -1,6 +1,4 @@
 /*
- * 02/08/2014
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletionListener.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletionListener.java
@@ -1,6 +1,4 @@
 /*
- * 02/08/2014
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletionStyleContext.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletionStyleContext.java
@@ -1,8 +1,4 @@
 /*
- * 06/24/2012
- *
- * AutoCompletionStyleContext.java - Manages styles related to auto-completion.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/BasicCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/BasicCompletion.java
@@ -1,8 +1,4 @@
 /*
- * 01/03/2009
- *
- * BasicCompletion.java - A straightforward Completion implementation.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/Completion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/Completion.java
@@ -1,8 +1,4 @@
 /*
- * 12/21/2008
- *
- * Completion.java - Represents a single completion choice.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionCellRenderer.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionCellRenderer.java
@@ -1,9 +1,4 @@
 /*
- * 12/23/2008
- *
- * CompletionCellRenderer.java - Cell renderer that can render the standard
- * completion types like Eclipse or NetBeans does.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionListModel.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionListModel.java
@@ -1,8 +1,4 @@
 /*
- * 12/22/2008
- *
- * CompletionListModel.java - A model that allows bulk addition of elements.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionProvider.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionProvider.java
@@ -1,9 +1,4 @@
 /*
- * 12/21/2008
- *
- * CompletionProvider.java - Provides autocompletion values based on the
- * text currently in a text component.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionProviderBase.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionProviderBase.java
@@ -1,8 +1,4 @@
 /*
- * 02/06/2010
- *
- * CompletionProviderBase.java - Base completion provider implementation.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionXMLParser.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionXMLParser.java
@@ -1,9 +1,4 @@
 /*
- * 02/06/2010
- *
- * CompletionXMLParser.java - Parses XML representing code completion for a
- * C-like language.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/DefaultCompletionProvider.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/DefaultCompletionProvider.java
@@ -1,8 +1,4 @@
 /*
- * 12/21/2008
- *
- * DefaultCompletionProvider.java - A basic completion provider implementation.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/DelegatingCellRenderer.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/DelegatingCellRenderer.java
@@ -1,9 +1,4 @@
 /*
- * 12/22/2008
- *
- * DelegatingCellRenderer.java - A renderer for Completions that will delegate
- * to the Completion's provider's renderer, if there is one.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/DescWindowCallback.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/DescWindowCallback.java
@@ -1,6 +1,4 @@
 /*
- * 05/11/2012
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/EmptyIcon.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/EmptyIcon.java
@@ -1,8 +1,4 @@
 /*
- * 04/29/2010
- *
- * EmptyIcon.java - The canonical icon that paints nothing.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ExternalURLHandler.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ExternalURLHandler.java
@@ -1,9 +1,4 @@
 /*
- * 12/23/2008
- *
- * ExternalURLHandler.java - Implementations can be registered as a callback
- * to handle the user clicking on external URLs.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/FastListUI.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/FastListUI.java
@@ -1,10 +1,4 @@
 /*
- * 04/26/2010
- *
- * FastListUI.java - A JList UI implementation that computes the preferred size
- * of all cells really fast, to facilitate lists of possibly thousands of items
- * rendered with HTML, which is slow with BasicListUI extensions.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/FunctionCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/FunctionCompletion.java
@@ -1,8 +1,4 @@
 /*
- * 12/22/2008
- *
- * FunctionCompletion.java - A completion representing a function.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/LanguageAwareCompletionProvider.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/LanguageAwareCompletionProvider.java
@@ -1,9 +1,4 @@
 /*
- * 01/03/2009
- *
- * LanguageAwareCompletionProvider.java - A completion provider that is aware
- * of the language it is working with.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/LinkRedirector.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/LinkRedirector.java
@@ -1,6 +1,4 @@
 /*
- * 05/16/2012
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/MarkupTagCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/MarkupTagCompletion.java
@@ -1,9 +1,4 @@
 /*
- * 01/06/2009
- *
- * MarkupTagCompletion.java - A completion representing a tag in markup, such
- * as HTML or XML.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/OutlineHighlightPainter.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/OutlineHighlightPainter.java
@@ -1,9 +1,4 @@
 /*
- * 04/26/2009
- *
- * OutlineHighlightPainter.java - Highlight painter that draws an outline
- * around its text.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterChoicesProvider.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterChoicesProvider.java
@@ -1,9 +1,4 @@
 /*
- * 12/14/2010
- *
- * ParameterChoicesProvider.java - Provides completions for a
- * ParameterizedCompletion's parameters.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletion.java
@@ -1,8 +1,4 @@
 /*
- * 12/11/2010
- *
- * ParameterizedCompletion.java - A completion option.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionChoicesWindow.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionChoicesWindow.java
@@ -1,9 +1,4 @@
 /*
- * 12/11/2010
- *
- * ParameterizedCompletionChoicesWindow.java - A list of likely choices for a
- * parameter.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionContext.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionContext.java
@@ -1,9 +1,4 @@
 /*
- * 06/17/2012
- *
- * ParameterizedCompletionContext.java - Manages the state of parameterized
- * completion-related UI components during code completion.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionDescriptionToolTip.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionDescriptionToolTip.java
@@ -1,9 +1,4 @@
 /*
- * 12/21/2008
- *
- * ParameterizedCompletionDescriptionToolTip.java - A "tool tip" displaying
- * information on the function or method currently being entered.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionInsertionInfo.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionInsertionInfo.java
@@ -1,9 +1,4 @@
 /*
- * 05/26/2012
- *
- * ParameterizedCompletionInsertionInfo.java - Used internally to track the
- * changes required for a specific parameterized completion.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/RoundRobinAutoCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/RoundRobinAutoCompletion.java
@@ -1,8 +1,6 @@
 /*
- * 12/02/2013
- *
  * This library is distributed under a modified BSD license.  See the included
- * AutoComplete.License.txt file for details.
+ * LICENSE.md file for details.
  */
 package org.fife.ui.autocomplete;
 

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ShorthandCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ShorthandCompletion.java
@@ -1,9 +1,4 @@
 /*
- * 12/22/2008
- *
- * ShorthandCompletion.java - A completion that is shorthand for some other
- * text.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/SizeGrip.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/SizeGrip.java
@@ -1,9 +1,4 @@
 /*
- * 12/23/2008
- *
- * SizeGrip.java - A size grip component that sits at the bottom of the window,
- * allowing the user to easily resize that window.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/SortByRelevanceComparator.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/SortByRelevanceComparator.java
@@ -1,9 +1,4 @@
 /*
- * 12/17/2010
- *
- * SortByRelevanceComparator.java - Sorts two Completions by relevance before
- * sorting them lexicographically.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/TemplateCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/TemplateCompletion.java
@@ -1,10 +1,4 @@
 /*
- * 05/26/2012
- *
- * TemplateCompletion.java - A completion used to insert boilerplate code
- * snippets that have arbitrary sections the user will want to change, such as
- * for-loops.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/TemplatePiece.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/TemplatePiece.java
@@ -1,8 +1,4 @@
 /*
- * 06/17/2012
- *
- * TemplatePiece.java - A logical piece of a template completion.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/TipUtil.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/TipUtil.java
@@ -1,8 +1,4 @@
 /*
- * 08/13/2009
- *
- * TipUtil.java - Utility methods for homemade tool tips.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/Util.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/Util.java
@@ -1,8 +1,4 @@
 /*
- * 12/21/2008
- *
- * Util.java - Utility methods for the autocompletion package.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/VariableCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/VariableCompletion.java
@@ -1,8 +1,4 @@
 /*
- * 12/22/2008
- *
- * VariableCompletion.java - A completion for a variable.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoCompleteDemo/src/main/java/org/fife/ui/autocomplete/demo/AutoCompleteDemoApp.java
+++ b/AutoCompleteDemo/src/main/java/org/fife/ui/autocomplete/demo/AutoCompleteDemoApp.java
@@ -1,8 +1,4 @@
 /*
- * 12/21/2008
- *
- * AutoCompleteDemoApp.java - A demo program for the auto-completion library.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoCompleteDemo/src/main/java/org/fife/ui/autocomplete/demo/CCellRenderer.java
+++ b/AutoCompleteDemo/src/main/java/org/fife/ui/autocomplete/demo/CCellRenderer.java
@@ -1,8 +1,4 @@
 /*
- * 01/07/2009
- *
- * CCellRenderer.java - A cell renderer for C completions.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/AutoCompleteDemo/src/main/java/org/fife/ui/autocomplete/demo/DemoRootPane.java
+++ b/AutoCompleteDemo/src/main/java/org/fife/ui/autocomplete/demo/DemoRootPane.java
@@ -1,8 +1,4 @@
 /*
- * 01/13/2009
- *
- * DemoRootPane.java - Root pane for the demo applet and standalone application.
- *
  * This library is distributed under a modified BSD license.  See the included
  * LICENSE.md file for details.
  */

--- a/config/checkstyle/javaHeader.txt
+++ b/config/checkstyle/javaHeader.txt
@@ -1,1 +1,4 @@
 /*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE.md file for details.
+ */


### PR DESCRIPTION
## Summary
- Drop the redundant filename/creation-date/description lines from each source file's header comment, keeping just the license notice
- Update `config/checkstyle/javaHeader.txt` to match the new, shorter header

## Test plan
- [x] `./gradlew clean build` passes (checkstyle, spotbugs, tests all green)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)