### PR TITLE
fix: include first overload when searching for matching completions

### DIFF
--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AbstractCompletionProvider.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AbstractCompletionProvider.java
@@ -177,7 +177,7 @@ public abstract class AbstractCompletionProvider
 				// of one of those overloads, but we must return all of them,
 				// so search backward until we find the first one.
 				int pos = index - 1;
-				while (pos>0 &&
+				while (pos>=0 &&
 						comparator.compare(completions.get(pos), text)==0) {
 					retVal.add(completions.get(pos));
 					pos--;

--- a/AutoComplete/src/test/java/org/fife/ui/autocomplete/AbstractCompletionProviderTest.java
+++ b/AutoComplete/src/test/java/org/fife/ui/autocomplete/AbstractCompletionProviderTest.java
@@ -1,0 +1,46 @@
+/*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE.md file for details.
+ */
+package org.fife.ui.autocomplete;
+
+import javax.swing.JTextArea;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class AbstractCompletionProviderTest {
+
+	/**
+	 * Regression test for https://github.com/bobbylight/AutoComplete/issues/101 -
+	 * when several completions share the same input text (e.g. overloaded
+	 * methods), the first one in the sorted completion list was never
+	 * included in the returned results, due to an off-by-one error.
+	 */
+	@Test
+	void getCompletions_allOverloadsReturned_evenTheFirstOneInTheList() {
+
+		DefaultCompletionProvider provider = new DefaultCompletionProvider();
+		BasicCompletion overload1 = new BasicCompletion(provider, "get", "overload 1");
+		BasicCompletion overload2 = new BasicCompletion(provider, "get", "overload 2");
+		BasicCompletion overload3 = new BasicCompletion(provider, "get", "overload 3");
+		provider.addCompletion(overload1);
+		provider.addCompletion(overload2);
+		provider.addCompletion(overload3);
+
+		JTextArea textArea = new JTextArea("get");
+		textArea.setCaretPosition(textArea.getText().length());
+
+		List<Completion> completions = provider.getCompletions(textArea);
+
+		Assertions.assertEquals(3, completions.size());
+		Assertions.assertTrue(completions.contains(overload1));
+		Assertions.assertTrue(completions.contains(overload2));
+		Assertions.assertTrue(completions.contains(overload3));
+
+	}
+
+
+}


### PR DESCRIPTION
## Summary
- Fixes an off-by-one error in `AbstractCompletionProvider.getCompletionsImpl()` where the backward search for sibling overloads used `pos>0` instead of `pos>=0`, causing the completion at index 0 of a matching group to be silently dropped from results.
- Adds a regression test that reproduces the bug with three completions sharing the same input text.

Fixes #101

## Test plan
- [x] Added `AbstractCompletionProviderTest#getCompletions_allOverloadsReturned_evenTheFirstOneInTheList`, verified it fails against the pre-fix code and passes with the fix.
- [x] `./gradlew :AutoComplete:test` passes.