### PR TITLE
fix: use DocumentEvent offset, not caret position, for auto-activation checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!--
+Enter a 1-3 sentence description of this PR in this section. This should be
+an overview of the bug and/or motivation for the changes. No implementation
+details.
+
+If this PR fixes an issue in the issue tracker, add a final one-sentence
+paragraph to this section of the form `Fixes #xxx`, where "xxx" is the issue
+number.
+-->
+
+## Details
+
+<--
+Start with 1-2 sentences describing *what* has changed, e.g. the "how" the
+change was implemented. If the change set is small and straightforward, this
+is all that's needed in this section.
+
+If it's a more complex change, or modifies a lot of files, also include a
+bulleted list that highlights important changes in the PR. Note this doesn't
+have to be a huge list, but should include anything noteworthy or that should
+not be missed by a reviewer.
+-->
+
+## Test plan
+
+<--
+Add any manual tests that should be performed to verify this fix before
+merging. If there are none, this entire section can be omitted.
+-->

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletion.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/AutoCompletion.java
@@ -1367,7 +1367,7 @@ public class AutoCompletion {
 			justInserted = false;
 			if (isAutoCompleteEnabled() && isAutoActivationEnabled() &&
 					e.getLength() == 1) {
-				if (textComponent != null && provider.isAutoActivateOkay(textComponent)) {
+				if (textComponent != null && provider.isAutoActivateOkay(textComponent, e.getOffset())) {
 					timer.restart();
 					justInserted = true;
 				}

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionProvider.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionProvider.java
@@ -154,16 +154,21 @@ public interface CompletionProvider {
 	/**
 	 * This method is called if auto-activation is enabled in the parent
 	 * {@link AutoCompletion} after the user types a single character.  This
-	 * provider should check the text at the current caret position of the
+	 * provider should check the text at the offset just inserted into the
 	 * text component, and decide whether auto-activation would be appropriate
 	 * here.  For example, a <code>CompletionProvider</code> for Java might
 	 * want to return <code>true</code> for this method only if the last
 	 * character typed was a '<code>.</code>'.
 	 *
 	 * @param tc The text component.
+	 * @param offs The offset of the character just inserted into the text
+	 *        component.  This is passed explicitly, rather than being
+	 *        derived from the text component's caret position, since the
+	 *        caret is not guaranteed to have been updated yet when this
+	 *        method is called.
 	 * @return Whether auto-activation would be appropriate.
 	 */
-	boolean isAutoActivateOkay(JTextComponent tc);
+	boolean isAutoActivateOkay(JTextComponent tc, int offs);
 
 
 	/**

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionProviderBase.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/CompletionProviderBase.java
@@ -170,11 +170,11 @@ public abstract class CompletionProviderBase implements CompletionProvider {
 
 
 	@Override
-	public boolean isAutoActivateOkay(JTextComponent tc) {
+	public boolean isAutoActivateOkay(JTextComponent tc, int offs) {
 		Document doc = tc.getDocument();
 		char ch = 0;
 		try {
-			doc.getText(tc.getCaretPosition(), 1, s);
+			doc.getText(offs, 1, s);
 			ch = s.first();
 		} catch (BadLocationException ble) { // Never happens
 			ble.printStackTrace();

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/LanguageAwareCompletionProvider.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/LanguageAwareCompletionProvider.java
@@ -303,9 +303,9 @@ public class LanguageAwareCompletionProvider extends CompletionProviderBase
 
 
 	@Override
-	public boolean isAutoActivateOkay(JTextComponent tc) {
+	public boolean isAutoActivateOkay(JTextComponent tc, int offs) {
 		CompletionProvider provider = getProviderFor(tc);
-		return provider != null && provider.isAutoActivateOkay(tc);
+		return provider != null && provider.isAutoActivateOkay(tc, offs);
 	}
 
 

--- a/AutoComplete/src/test/java/org/fife/ui/autocomplete/AutoCompletionTest.java
+++ b/AutoComplete/src/test/java/org/fife/ui/autocomplete/AutoCompletionTest.java
@@ -7,14 +7,18 @@ package org.fife.ui.autocomplete;
 import java.awt.GraphicsEnvironment;
 import javax.swing.JFrame;
 import javax.swing.JTextArea;
+import javax.swing.text.DefaultCaret;
+import javax.swing.text.JTextComponent;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 
+@ExtendWith(SwingRunnerExtension.class)
 class AutoCompletionTest {
 
 	private JFrame frame;
@@ -36,7 +40,7 @@ class AutoCompletionTest {
 
 
 	/**
-	 * Regression test for https://github.com/bobbylight/AutoComplete/issues/84 -
+	 * Regression test for <a href="https://github.com/bobbylight/AutoComplete/issues/84">Issue #84</a> -
 	 * merely hiding the description window when it's toggled off could leave
 	 * a blank "ghost" window on screen on some Linux/X11 window managers.
 	 * The fix disposes of the description window's native peer instead of
@@ -81,6 +85,113 @@ class AutoCompletionTest {
 				"Description window should be disposed and discarded, not just hidden");
 		Assertions.assertFalse(descWindow.isDisplayable(),
 				"Description window's native peer should be destroyed by dispose()");
+
+	}
+
+
+	/**
+	 * Regression test for <a href="https://github.com/bobbylight/AutoComplete/issues/77">Issue #77</a> -
+	 * {@code isAutoActivateOkay()} used to look at {@code JTextComponent#getCaretPosition()}
+	 * to find the just-typed character, but the caret is not guaranteed to have been
+	 * updated yet when {@code insertUpdate()} fires; it depends on the order in which
+	 * document listeners were registered.  This test simulates the "default" ordering,
+	 * where the caret has *not yet* been moved to reflect the inserted character by the
+	 * time {@code AutoCompletion}'s listener runs (this is the ordering that always
+	 * worked, even before the fix, since the stale caret position happened to coincide
+	 * with the newly-inserted character's offset).
+	 */
+	@Test
+	void insertUpdate_autoActivateOkay_correctWhenCaretListenerFiresAfterAutoCompletion() {
+
+		RecordingCompletionProvider recordingProvider = new RecordingCompletionProvider();
+		recordingProvider.setAutoActivationRules(false, ".");
+
+		AutoCompletion ac = new AutoCompletion(recordingProvider);
+		ac.setAutoActivationEnabled(true);
+
+		// Note - the default Caret will be installed here, and thus before the AutoCompletion.
+		// Events are fired last-first so the AC will receive the {@code insertEvent} before
+		// the caret's offset is updated. This is the OOTB default behavior.
+		JTextArea textArea = new JTextArea();
+
+		ac.install(textArea);
+
+		textArea.setCaretPosition(0);
+		textArea.replaceSelection(".");
+
+		Assertions.assertEquals(0, recordingProvider.lastOffset,
+				"isAutoActivateOkay() should receive the offset of the inserted character");
+		Assertions.assertEquals(0, recordingProvider.caretPositionAtCallTime,
+				"Caret should still be stale (unmoved) in this listener ordering");
+		Assertions.assertTrue(recordingProvider.lastResult,
+				"Auto-activation should trigger for '.' regardless of caret staleness");
+
+	}
+
+
+	/**
+	 * Regression test for <a href="https://github.com/bobbylight/AutoComplete/issues/77">Issue #77</a> -
+	 * this simulates the "other" ordering reported in the issue (e.g. after
+	 * {@code TextEditorPane#load()} swaps in a new {@code Document}), where the caret
+	 * *has already* been moved to reflect the inserted character by the time
+	 * {@code AutoCompletion}'s listener runs.  Before the fix, {@code isAutoActivateOkay()}
+	 * would read {@code doc.getText(tc.getCaretPosition(), 1)}, which in this ordering
+	 * points one character past the just-typed character (i.e. off the end of the
+	 * document in this test), so auto-activation would incorrectly fail to trigger.
+	 * <p>
+	 * Example real-world reproduction case: Install an {@code AutoCompletion} on a text area, then
+	 * call {@code setCaret(new DefaultCaret())}. This reinstalls the Caret's listeners and thus flips
+	 * the notification ordering between it and the AutoCompletion.
+	 * <p>
+	 * Note: This is only reproducible when run on the EDT (which a well-behaved app should always do!).
+	 */
+	@Test
+	void insertUpdate_autoActivateOkay_correctWhenCaretListenerFiresBeforeAutoCompletion() {
+
+		RecordingCompletionProvider recordingProvider = new RecordingCompletionProvider();
+		recordingProvider.setAutoActivationRules(false, ".");
+
+		AutoCompletion ac = new AutoCompletion(recordingProvider);
+		ac.setAutoActivationEnabled(true);
+
+		JTextArea textArea = new JTextArea();
+		ac.install(textArea);
+
+		// Register a new caret so the installed caret's listener order will be *after* the AutoCompletion's.
+		// This in turn makes the Caret notified before the AC (listeners are notified in reverse order),
+		// allowing us to test that our code is agnostic to listener ordering.
+		textArea.setCaret(new DefaultCaret());
+
+		textArea.setCaretPosition(0);
+		textArea.replaceSelection(".");
+
+		Assertions.assertEquals(0, recordingProvider.lastOffset,
+				"isAutoActivateOkay() should receive the offset of the inserted character");
+		Assertions.assertEquals(1, recordingProvider.caretPositionAtCallTime,
+				"Caret should already be advanced past the inserted character in this ordering");
+		Assertions.assertTrue(recordingProvider.lastResult,
+				"Auto-activation should trigger for '.' regardless of caret staleness");
+
+	}
+
+
+	/**
+	 * A completion provider that records the arguments and return value of the most
+	 * recent call to {@code isAutoActivateOkay()}.
+	 */
+	private static final class RecordingCompletionProvider extends DefaultCompletionProvider {
+
+		int lastOffset = -1;
+		int caretPositionAtCallTime = -1;
+		boolean lastResult;
+
+		@Override
+		public boolean isAutoActivateOkay(JTextComponent tc, int offs) {
+			lastOffset = offs;
+			caretPositionAtCallTime = tc.getCaretPosition();
+			lastResult = super.isAutoActivateOkay(tc, offs);
+			return lastResult;
+		}
 
 	}
 

--- a/AutoComplete/src/test/java/org/fife/ui/autocomplete/SwingRunnerExtension.java
+++ b/AutoComplete/src/test/java/org/fife/ui/autocomplete/SwingRunnerExtension.java
@@ -1,0 +1,43 @@
+/*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE file for details.
+ */
+package org.fife.ui.autocomplete;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+import javax.swing.*;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReference;
+
+
+/**
+ * Runs Swing unit tests on the EDT.
+ *
+ * @author Robert Futrell
+ * @version 1.0
+ */
+public class SwingRunnerExtension implements InvocationInterceptor {
+
+	@Override
+	public void interceptTestMethod(Invocation<Void> invocation,
+                                    ReflectiveInvocationContext<Method> invocationContext,
+                                    ExtensionContext extensionContext) throws Throwable {
+
+		AtomicReference<Throwable> throwable = new AtomicReference<>();
+
+		SwingUtilities.invokeAndWait(() -> {
+			try {
+				invocation.proceed();
+			} catch (Throwable t) {
+				throwable.set(t);
+			}
+		});
+		Throwable t = throwable.get();
+		if (t != null) {
+			throw t;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`isAutoActivateOkay()` checked the character at the text component's caret position, but the caret is not guaranteed to have been updated yet when the `insertUpdate()` `DocumentListener` callback fires, so behavior depended on incidental document-listener ordering.

Fixes #77

## Details

`CompletionProvider.isAutoActivateOkay(JTextComponent)` is now `isAutoActivateOkay(JTextComponent, int offs)`, with the offset sourced from `DocumentEvent#getOffset()` in `AutoCompletion`'s `insertUpdate()` listener, which is authoritative regardless of caret/listener timing.

- `CompletionProviderBase.isAutoActivateOkay()` now reads the character at the passed-in `offs` instead of `tc.getCaretPosition()`.
- `LanguageAwareCompletionProvider.isAutoActivateOkay()` forwards the new `offs` param to its delegate provider.
- This is an API change to `CompletionProvider` and its implementations, acceptable per the maintainer for a major version bump.

## Test plan

- [x] `./gradlew :AutoComplete:test` — all existing tests pass (3 classes, 4 tests, 0 failures)
- [x] `./gradlew :AutoComplete:compileJava` — compiles cleanly