### PR TITLE
build(deps): DocumentRange RSyntaxTextArea 4.0.1 compatibility

### DIFF
--- a/AutoComplete/build.gradle
+++ b/AutoComplete/build.gradle
@@ -9,7 +9,7 @@ base {
 }
 
 dependencies {
-    api 'com.fifesoft:rsyntaxtextarea:3.6.1'
+    api 'com.fifesoft:rsyntaxtextarea:4.0.1'
 }
 
 ext.isReleaseVersion = !project.version.endsWith('SNAPSHOT')

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionContext.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionContext.java
@@ -38,10 +38,9 @@ import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.fife.ui.autocomplete.ParameterizedCompletion.Parameter;
 import org.fife.ui.autocomplete.ParameterizedCompletionInsertionInfo.ReplacementCopy;
-import org.fife.ui.rsyntaxtextarea.DocumentRange;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rtextarea.ChangeableHighlightPainter;
-
+import org.fife.ui.rtextarea.DocumentRange;
 
 /**
  * Manages UI and state specific to parameterized completions - the parameter

--- a/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionInsertionInfo.java
+++ b/AutoComplete/src/main/java/org/fife/ui/autocomplete/ParameterizedCompletionInsertionInfo.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.swing.text.Position;
 
-import org.fife.ui.rsyntaxtextarea.DocumentRange;
+import org.fife.ui.rtextarea.DocumentRange;
 
 
 /**


### PR DESCRIPTION
With this change: https://github.com/bobbylight/RSyntaxTextArea/commit/eaac5af2942819ed07c3670527bf1c43a55afbf9 compatibility was broken to AutoComplete.
This simple change uses the new correct package for DocumentRange and switches to RSyntaxTextArea 4.0.1